### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -17,7 +17,7 @@ stilts = { path = "../" }
 
 [dev-dependencies]
 stilts = { path = "../", features = ["err-fancy"]}
-divan = "0.1.5"
+divan = "0.1.11"
 
 [[bench]]
 name = "all"

--- a/testing/benches/all.rs
+++ b/testing/benches/all.rs
@@ -24,12 +24,12 @@ struct Team {
 
 const SIZES: &[usize] = &[1, 2, 8, 16, 32, 64, 128, 256, 512, 1024];
 
-#[divan::bench(consts = SIZES)]
-fn big_table<const SIZE: usize>(b: divan::Bencher) {
-    let mut table = Vec::with_capacity(SIZE);
-    for _ in 0..SIZE {
-        let mut inner = Vec::with_capacity(SIZE);
-        for i in 0..SIZE {
+#[divan::bench(args = SIZES)]
+fn big_table(b: divan::Bencher, size: usize) {
+    let mut table = Vec::with_capacity(size);
+    for _ in 0..size {
+        let mut inner = Vec::with_capacity(size);
+        for i in 0..size {
             inner.push(i);
         }
         table.push(inner);


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.