### PR TITLE
render only a single block

### DIFF
--- a/book/src/language/inheritance_expressions.md
+++ b/book/src/language/inheritance_expressions.md
@@ -46,9 +46,13 @@ The same expression is used in parent and child templates to perform their relat
 defining a block means providing a section that any child templates **can** override, while in the
 child template defining a block means overridding the block that is defined by the parent.
 
-A *block* only works in conjunction with the *extends* expressions to provide an inheritance structure to reduce
+A *block* works in conjunction with the *extends* expressions to provide an inheritance structure to reduce
 template code duplication. This is best accomplished by writing most boilerplate into a base template that other
 child templates are able to extend and overwrite pieces of to create their own functionality.
+
+It is also possible to use *blocks* to render only parts of a larger template, by
+specifying the `block` attrimute on the `template` macro, alongside `path` or
+`content`. This can be useful for partial updates.
 
 ### base.html
 A parent/base template defines as many blocks as it wants wherever it wants. It can even put code

--- a/book/src/template_macro.md
+++ b/book/src/template_macro.md
@@ -27,6 +27,7 @@ Either **path** or **content** must be specified
 - **content**: The direct contents of the template provided by a string literal
 - **escape**: Override the escaper detected by file extension with a specified one
 - **trim**: Override the trim behavior defined in your config
+- **block**: Only use the contents of a specific block
 
 ### Examples:
 Standard use case
@@ -63,3 +64,11 @@ struct MyOverridenTemplate {
     my_data: String,
 }
 ```
+
+Only using a single block
+```rust,numbered
+#[derive(Template)]
+#[stilts(path = "index.html", block = "popup")]
+struct MyTemplate {
+    my_data: String,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub use extensions::{DebugExt, DisplayExt, SerializeExt};
 /// - **content**: The direct contents of the template provided by a string literal
 /// - **escape**: Override the escaper detected by file extension with a specified one
 /// - **trim**: Override the trim behavior defined in your config
+/// - **block**: Only use the contents of a specific block
 ///
 /// ## Examples:
 /// Standard use case
@@ -91,6 +92,15 @@ pub use extensions::{DebugExt, DisplayExt, SerializeExt};
 /// #[derive(Template)]
 /// #[stilts(content = "Templates are fun", trim = false, escape = ::stilts::escaping::Empty)]
 /// struct MyOverridenTemplate {
+///     my_data: String,
+/// }
+/// ```
+/// 
+/// Only using a single block
+/// ```ignore
+/// #[derive(Template)]
+/// #[stilts(path = "index.html", block = "popup")]
+/// struct MyTemplate {
 ///     my_data: String,
 /// }
 /// ```

--- a/stilts-macros/src/parse.rs
+++ b/stilts-macros/src/parse.rs
@@ -60,6 +60,7 @@ pub struct TemplateAttrs {
     pub source: TemplateSource,
     pub escape: Option<Path>,
     pub trim: Option<bool>,
+    pub block: Option<String>,
 }
 
 impl TemplateAttrs {
@@ -71,6 +72,7 @@ impl TemplateAttrs {
         let mut source = None;
         let mut escape = None;
         let mut trim = None;
+        let mut block = None;
 
         for attr in attrs {
             attr.parse_nested_meta(|meta| {
@@ -94,6 +96,11 @@ impl TemplateAttrs {
                     let value: LitBool = value.parse()?;
                     trim = Some(value.value)
                 }
+                if meta.path.is_ident("block") {
+                    let value = meta.value()?;
+                    let value: LitStr = value.parse()?;
+                    block = Some(value.value());
+                }
                 Ok(())
             })?;
         }
@@ -103,6 +110,7 @@ impl TemplateAttrs {
             source,
             escape,
             trim,
+            block,
         })
     }
 }

--- a/testing/tests/block_isolation.rs
+++ b/testing/tests/block_isolation.rs
@@ -1,0 +1,22 @@
+#![warn(clippy::pedantic)]
+
+use stilts::Template;
+
+#[derive(Template)]
+#[stilts(path = "sample.html", block = "main")]
+struct MyTemplate<'a> {
+    a: &'a str,
+}
+
+#[test]
+fn ensure_matches() {
+    const EXPECTED: &str = r#"Hello Word<a href="/">MY MAN</a>my code content <a></a>"#;
+
+    let val = MyTemplate {
+        a: "my code content <a></a>",
+    }
+    .render()
+    .unwrap();
+
+    assert_eq!(val, EXPECTED);
+}

--- a/testing/tests/block_isolation.rs
+++ b/testing/tests/block_isolation.rs
@@ -4,16 +4,38 @@ use stilts::Template;
 
 #[derive(Template)]
 #[stilts(path = "sample.html", block = "main")]
-struct MyTemplate<'a> {
+struct ChildTemplate<'a> {
     a: &'a str,
 }
 
 #[test]
-fn ensure_matches() {
+fn ensure_child() {
     const EXPECTED: &str = r#"Hello Word<a href="/">MY MAN</a>my code content <a></a>"#;
 
-    let val = MyTemplate {
+    let val = ChildTemplate {
         a: "my code content <a></a>",
+    }
+    .render()
+    .unwrap();
+
+    assert_eq!(val, EXPECTED);
+}
+
+#[derive(Template)]
+#[stilts(
+    content = "<em> {% block main %} <strong> {% a %} </strong> {% end %} </em>",
+    block = "main"
+)]
+struct SoloTemplate<'a> {
+    a: &'a str,
+}
+
+#[test]
+fn ensure_solo() {
+    const EXPECTED: &str = r#"<strong>Hey</strong>"#;
+
+    let val = SoloTemplate {
+        a: "Hey",
     }
     .render()
     .unwrap();


### PR DESCRIPTION
This PR implements a new attribute for the derive macro, called `block`. When present, only the content of the specified block is rendered.

When reviewing, please consider these factors:
1. Using inheritance is impossible. If present, the `{% extends … %}` outside the specified block is ignored. Any `{% extends … %}` within the block is also ignored, and AFAIK prevented earlier in the parsing process.
2. Most of the content of `TemplateNode` is changed. However, the `content` field of `TemplateData` isn't. I could not find any code accessing that field after the changes are made.

Strictly speaking, this feature doesn't enable any new use cases for the library. The same effect could be achieved by splitting of a new template and `{% include … %}`ing it in the original. However, this is nicer to use in some cases. An example would be input validation with HTMX.